### PR TITLE
Raw data download fields list

### DIFF
--- a/atlas_validation_config.json
+++ b/atlas_validation_config.json
@@ -77,7 +77,7 @@
   "singlecell_raw_data_sdrf_fields": [
     "fastq_uri",
     "sra_uri"
-  ]
+  ],
   "ae_experiment_types": {
     "microarray": [
       "antigen profiling",

--- a/atlas_validation_config.json
+++ b/atlas_validation_config.json
@@ -74,7 +74,7 @@
     "cell barcode read",
     "umi barcode read"
   ],
-  "singlecell_raw_data_sdrf_fields": [
+  "raw_data_download_sdrf_fields": [
     "fastq_uri",
     "sra_uri"
   ],

--- a/atlas_validation_config.json
+++ b/atlas_validation_config.json
@@ -53,7 +53,6 @@
     "library_selection",
     "library_source",
     "library_strand",
-    "fastq_uri",
     "library construction",
     "single cell isolation"
   ],
@@ -75,6 +74,10 @@
     "cell barcode read",
     "umi barcode read"
   ],
+  "singlecell_raw_data_sdrf_fields": [
+    "fastq_uri",
+    "sra_uri"
+  ]
   "ae_experiment_types": {
     "microarray": [
       "antigen profiling",


### PR DESCRIPTION
This removes FASTQ_URI from the required SDRF fields and adds it to a new list of download fields (of which at least one will be required). 